### PR TITLE
Fix initial value for rect calculation

### DIFF
--- a/FaceAware/UIImageView+FaceAware.swift
+++ b/FaceAware/UIImageView+FaceAware.swift
@@ -59,7 +59,7 @@ public extension UIImageView {
     }
     
     private func applyFaceDetection(for features: [AnyObject], size: CGSize, cgImage: CGImage) {
-        var rect = CGRect.zero
+        var rect = features[0].bounds!
         var rightBorder = 0.0
         var bottomBorder = 0.0
         

--- a/FaceAware/UIImageView+FaceAware.swift
+++ b/FaceAware/UIImageView+FaceAware.swift
@@ -60,10 +60,11 @@ public extension UIImageView {
     
     private func applyFaceDetection(for features: [AnyObject], size: CGSize, cgImage: CGImage) {
         var rect = features[0].bounds!
-        var rightBorder = 0.0
-        var bottomBorder = 0.0
+        rect.origin.y = size.height - rect.origin.y - rect.size.height
+        var rightBorder = Double(rect.origin.x + rect.size.width)
+        var bottomBorder = Double(rect.origin.y + rect.size.height)
         
-        for feature in features {
+        for feature in features[1..<features.count] {
             var oneRect = feature.bounds!
             oneRect.origin.y = size.height - oneRect.origin.y - oneRect.size.height
             rect.origin.x = min(oneRect.origin.x, rect.origin.x)


### PR DESCRIPTION
Fix for #10 

When iterating features rect origin is updated like this:
```
            rect.origin.x = min(oneRect.origin.x, rect.origin.x)
            rect.origin.y = min(oneRect.origin.y, rect.origin.y)
```
But initial value for rect.origin was zero - this prevented rect.origin.x and y from being >0. This PR fixes it by using first feature's bounds as initial value.